### PR TITLE
feat: support WAKATIME_HOME like wakatime cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ Inspired by [claude-code-wakatime](https://github.com/wakatime/claude-code-wakat
 
 ### WakaTime API Key
 
-Ensure you have a WakaTime API key configured in `~/.wakatime.cfg`:
+Ensure you have a WakaTime API key configured in `~/.wakatime.cfg`
+(or `$WAKATIME_HOME/.wakatime.cfg` when `WAKATIME_HOME` is set):
 
 ```ini
 [settings]
@@ -144,13 +145,16 @@ Each heartbeat includes:
 
 ## Files
 
-| File                                  | Purpose                                    |
-| ------------------------------------- | ------------------------------------------ |
-| `~/.wakatime/opencode.log`                  | Debug logs (enabled via `debug=true` in `~/.wakatime.cfg`) |
-| `~/.wakatime/opencode-{hash}.json`          | Per-project state (last heartbeat timestamp) |
-| `~/.wakatime/opencode-cli-state.json`       | CLI version tracking                       |
-| `~/.wakatime/opencode-version-cache.json`   | Cached OpenCode server version             |
-| `~/.wakatime/wakatime-cli-*`                | Auto-downloaded CLI binary                 |
+By default, plugin files are stored in `~/.wakatime/`.
+When `WAKATIME_HOME` is set, the same files are stored in `$WAKATIME_HOME/`.
+
+| File                        | Purpose                                    |
+| --------------------------- | ------------------------------------------ |
+| `opencode.log`              | Debug logs (enabled via `debug=true` in `~/.wakatime.cfg`) |
+| `opencode-{hash}.json`      | Per-project state (last heartbeat timestamp) |
+| `opencode-cli-state.json`   | CLI version tracking                       |
+| `opencode-version-cache.json` | Cached OpenCode server version             |
+| `wakatime-cli-*`            | Auto-downloaded CLI binary                 |
 
 ## Development
 
@@ -178,11 +182,13 @@ npm run build
 1. Verify API key in `~/.wakatime.cfg`
 2. Check if wakatime-cli is working: `wakatime-cli --version`
 3. Enable debug logging and check `~/.wakatime/opencode.log`
+   (or `$WAKATIME_HOME/opencode.log` when set)
 
 ### CLI not downloading
 
 1. Check network connectivity
 2. Verify write permissions to `~/.wakatime/`
+   (or `$WAKATIME_HOME/` when set)
 3. Manually install: `brew install wakatime-cli`
 
 ## License

--- a/src/__tests__/dependencies.test.ts
+++ b/src/__tests__/dependencies.test.ts
@@ -18,12 +18,11 @@ const { Dependencies } = await import("../dependencies.js");
 
 describe("Dependencies", () => {
   let deps: InstanceType<typeof Dependencies>;
-  const originalEnv = process.env;
 
   beforeEach(() => {
     vi.resetAllMocks();
-    process.env = { ...originalEnv };
-    delete process.env.WAKATIME_HOME;
+    vi.unstubAllEnvs();
+    vi.stubEnv("WAKATIME_HOME", undefined);
     vi.mocked(os.homedir).mockReturnValue("/home/user");
     vi.mocked(os.platform).mockReturnValue("darwin");
     vi.mocked(os.arch).mockReturnValue("x64");
@@ -35,7 +34,7 @@ describe("Dependencies", () => {
   });
 
   afterEach(() => {
-    process.env = originalEnv;
+    vi.unstubAllEnvs();
     vi.restoreAllMocks();
   });
 
@@ -126,7 +125,7 @@ describe("Dependencies", () => {
     });
 
     it("uses WAKATIME_HOME for local CLI location when set", () => {
-      process.env.WAKATIME_HOME = "/custom/wakatime";
+      vi.stubEnv("WAKATIME_HOME", "/custom/wakatime");
       vi.mocked(os.platform).mockReturnValue("darwin");
       vi.mocked(os.arch).mockReturnValue("arm64");
       vi.mocked(child_process.execSync).mockImplementation(() => {

--- a/src/__tests__/state.test.ts
+++ b/src/__tests__/state.test.ts
@@ -22,8 +22,6 @@ const {
 } = await import("../state.js");
 
 describe("state", () => {
-  const originalEnv = process.env;
-
   // Compute expected hash for test project folder
   const testProjectFolder = "/home/user/projects/myapp";
   const expectedHash = crypto
@@ -39,15 +37,15 @@ describe("state", () => {
 
   beforeEach(() => {
     vi.resetAllMocks();
-    process.env = { ...originalEnv };
-    delete process.env.WAKATIME_HOME;
+    vi.unstubAllEnvs();
+    vi.stubEnv("WAKATIME_HOME", undefined);
     vi.mocked(os.homedir).mockReturnValue("/home/user");
     // Initialize state with test project folder for consistent file path
     initState(testProjectFolder);
   });
 
   afterEach(() => {
-    process.env = originalEnv;
+    vi.unstubAllEnvs();
     vi.restoreAllMocks();
   });
 
@@ -90,7 +88,7 @@ describe("state", () => {
     });
 
     it("uses WAKATIME_HOME when set", () => {
-      process.env.WAKATIME_HOME = "/custom/wakatime";
+      vi.stubEnv("WAKATIME_HOME", "/custom/wakatime");
       const projectFolder = "/home/user/projects/wakatime-home-project";
       initState(projectFolder);
 

--- a/src/__tests__/wakatime-paths.test.ts
+++ b/src/__tests__/wakatime-paths.test.ts
@@ -13,21 +13,18 @@ const {
 } = await import("../wakatime-paths.js");
 
 describe("wakatime-paths", () => {
-  const originalEnv = process.env;
-
   beforeEach(() => {
-    process.env = { ...originalEnv };
+    vi.unstubAllEnvs();
+    vi.stubEnv("WAKATIME_HOME", undefined);
     vi.mocked(os.homedir).mockReturnValue("/home/user");
   });
 
   afterEach(() => {
-    process.env = originalEnv;
+    vi.unstubAllEnvs();
     vi.restoreAllMocks();
   });
 
   it("uses default home and .wakatime resources when WAKATIME_HOME is not set", () => {
-    delete process.env.WAKATIME_HOME;
-
     expect(getWakatimeHomeDir()).toBe("/home/user");
     expect(getWakatimeResourcesDir()).toBe(
       path.join("/home/user", ".wakatime"),
@@ -38,7 +35,7 @@ describe("wakatime-paths", () => {
   });
 
   it("uses WAKATIME_HOME directly for resources and config", () => {
-    process.env.WAKATIME_HOME = "/custom/wakatime";
+    vi.stubEnv("WAKATIME_HOME", "/custom/wakatime");
 
     expect(getWakatimeHomeDir()).toBe("/custom/wakatime");
     expect(getWakatimeResourcesDir()).toBe("/custom/wakatime");
@@ -48,7 +45,7 @@ describe("wakatime-paths", () => {
   });
 
   it("expands ~ in WAKATIME_HOME", () => {
-    process.env.WAKATIME_HOME = "~/waka-home";
+    vi.stubEnv("WAKATIME_HOME", "~/waka-home");
 
     expect(getWakatimeHomeDir()).toBe(path.join("/home/user", "waka-home"));
     expect(getWakatimeResourcesDir()).toBe(
@@ -57,7 +54,7 @@ describe("wakatime-paths", () => {
   });
 
   it("treats empty WAKATIME_HOME as unset", () => {
-    process.env.WAKATIME_HOME = "   ";
+    vi.stubEnv("WAKATIME_HOME", "   ");
 
     expect(getWakatimeHomeDir()).toBe("/home/user");
     expect(getWakatimeResourcesDir()).toBe(

--- a/src/__tests__/wakatime-paths.test.ts
+++ b/src/__tests__/wakatime-paths.test.ts
@@ -1,0 +1,67 @@
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:os", () => ({
+  homedir: vi.fn(() => "/home/user"),
+}));
+
+const {
+  getWakatimeConfigFilePath,
+  getWakatimeHomeDir,
+  getWakatimeResourcesDir,
+} = await import("../wakatime-paths.js");
+
+describe("wakatime-paths", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    vi.mocked(os.homedir).mockReturnValue("/home/user");
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  it("uses default home and .wakatime resources when WAKATIME_HOME is not set", () => {
+    delete process.env.WAKATIME_HOME;
+
+    expect(getWakatimeHomeDir()).toBe("/home/user");
+    expect(getWakatimeResourcesDir()).toBe(
+      path.join("/home/user", ".wakatime"),
+    );
+    expect(getWakatimeConfigFilePath()).toBe(
+      path.join("/home/user", ".wakatime.cfg"),
+    );
+  });
+
+  it("uses WAKATIME_HOME directly for resources and config", () => {
+    process.env.WAKATIME_HOME = "/custom/wakatime";
+
+    expect(getWakatimeHomeDir()).toBe("/custom/wakatime");
+    expect(getWakatimeResourcesDir()).toBe("/custom/wakatime");
+    expect(getWakatimeConfigFilePath()).toBe(
+      path.join("/custom/wakatime", ".wakatime.cfg"),
+    );
+  });
+
+  it("expands ~ in WAKATIME_HOME", () => {
+    process.env.WAKATIME_HOME = "~/waka-home";
+
+    expect(getWakatimeHomeDir()).toBe(path.join("/home/user", "waka-home"));
+    expect(getWakatimeResourcesDir()).toBe(
+      path.join("/home/user", "waka-home"),
+    );
+  });
+
+  it("treats empty WAKATIME_HOME as unset", () => {
+    process.env.WAKATIME_HOME = "   ";
+
+    expect(getWakatimeHomeDir()).toBe("/home/user");
+    expect(getWakatimeResourcesDir()).toBe(
+      path.join("/home/user", ".wakatime"),
+    );
+  });
+});

--- a/src/dependencies.ts
+++ b/src/dependencies.ts
@@ -5,6 +5,7 @@ import * as https from "node:https";
 import * as os from "node:os";
 import * as path from "node:path";
 import { logger } from "./logger.js";
+import { getWakatimeResourcesDir } from "./wakatime-paths.js";
 
 function whichSync(cmd: string): string | null {
   try {
@@ -39,7 +40,7 @@ export class Dependencies {
   private stateFile: string;
 
   constructor() {
-    this.resourcesLocation = path.join(os.homedir(), ".wakatime");
+    this.resourcesLocation = getWakatimeResourcesDir();
     this.stateFile = path.join(
       this.resourcesLocation,
       "opencode-cli-state.json",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 import * as fs from "node:fs";
-import * as os from "node:os";
 import * as path from "node:path";
 import type { Hooks, Plugin } from "@opencode-ai/plugin";
 import { LogLevel, logger } from "./logger.js";
@@ -9,6 +8,10 @@ import {
   updateLastHeartbeat,
 } from "./state.js";
 import { ensureCliInstalled, sendHeartbeat } from "./wakatime.js";
+import {
+  getWakatimeConfigFilePath,
+  getWakatimeResourcesDir,
+} from "./wakatime-paths.js";
 
 /**
  * Type definitions for OpenCode SDK event parts
@@ -66,8 +69,7 @@ const fileChanges = new Map<string, FileChangeInfo>();
 
 // Cache opencode version - written to a file so all plugin instances can share it
 const OPENCODE_VERSION_CACHE = path.join(
-  os.homedir(),
-  ".wakatime",
+  getWakatimeResourcesDir(),
   "opencode-version-cache.json",
 );
 
@@ -303,8 +305,8 @@ function trackFileChange(file: string, info: Partial<FileChangeInfo>): void {
 }
 
 export const plugin: Plugin = async (ctx) => {
-  // Read debug setting from ~/.wakatime.cfg [settings] section
-  const wakatimeCfgPath = path.join(os.homedir(), ".wakatime.cfg");
+  // Read debug setting from ~/.wakatime.cfg (or $WAKATIME_HOME/.wakatime.cfg)
+  const wakatimeCfgPath = getWakatimeConfigFilePath();
   try {
     const cfg = fs.readFileSync(wakatimeCfgPath, "utf-8");
     const debugMatch = cfg.match(/^\s*debug\s*=\s*true\s*$/m);

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs";
-import * as os from "node:os";
 import * as path from "node:path";
+import { getWakatimeResourcesDir } from "./wakatime-paths.js";
 
 export enum LogLevel {
   DEBUG = 0,
@@ -9,7 +9,9 @@ export enum LogLevel {
   ERROR = 3,
 }
 
-const LOG_FILE = path.join(os.homedir(), ".wakatime", "opencode.log");
+function getLogFilePath(): string {
+  return path.join(getWakatimeResourcesDir(), "opencode.log");
+}
 
 export class Logger {
   private level: LogLevel = LogLevel.INFO;
@@ -52,11 +54,12 @@ export class Logger {
     const line = `[${timestamp}][${levelName}] ${msg}\n`;
 
     try {
-      const dir = path.dirname(LOG_FILE);
+      const logFile = getLogFilePath();
+      const dir = path.dirname(logFile);
       if (!fs.existsSync(dir)) {
         fs.mkdirSync(dir, { recursive: true });
       }
-      fs.appendFileSync(LOG_FILE, line);
+      fs.appendFileSync(logFile, line);
     } catch {
       // Silently ignore logging errors
     }

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,16 +1,14 @@
 import * as crypto from "node:crypto";
 import * as fs from "node:fs";
-import * as os from "node:os";
 import * as path from "node:path";
-
-const STATE_DIR = path.join(os.homedir(), ".wakatime");
+import { getWakatimeResourcesDir } from "./wakatime-paths.js";
 
 export interface State {
   lastHeartbeatAt?: number;
 }
 
 // Project-specific state file path (set via initState)
-let stateFile = path.join(STATE_DIR, "opencode.json");
+let stateFile = path.join(getWakatimeResourcesDir(), "opencode.json");
 
 /**
  * Initialize state with a project-specific identifier.
@@ -23,7 +21,7 @@ export function initState(projectFolder: string): void {
     .update(projectFolder)
     .digest("hex")
     .slice(0, 8);
-  stateFile = path.join(STATE_DIR, `opencode-${hash}.json`);
+  stateFile = path.join(getWakatimeResourcesDir(), `opencode-${hash}.json`);
 }
 
 export function readState(): State {

--- a/src/wakatime-paths.ts
+++ b/src/wakatime-paths.ts
@@ -1,0 +1,36 @@
+import * as os from "node:os";
+import * as path from "node:path";
+
+function getWakatimeHomeFromEnv(): string | undefined {
+  const value = process.env.WAKATIME_HOME?.trim();
+  if (!value) {
+    return undefined;
+  }
+
+  if (value === "~") {
+    return os.homedir();
+  }
+
+  if (value.startsWith("~/") || value.startsWith("~\\")) {
+    return path.join(os.homedir(), value.slice(2));
+  }
+
+  return value;
+}
+
+export function getWakatimeHomeDir(): string {
+  return getWakatimeHomeFromEnv() ?? os.homedir();
+}
+
+export function getWakatimeResourcesDir(): string {
+  const wakatimeHome = getWakatimeHomeFromEnv();
+  if (wakatimeHome) {
+    return wakatimeHome;
+  }
+
+  return path.join(os.homedir(), ".wakatime");
+}
+
+export function getWakatimeConfigFilePath(): string {
+  return path.join(getWakatimeHomeDir(), ".wakatime.cfg");
+}


### PR DESCRIPTION
## what changed
- add `WAKATIME_HOME` support so paths match wakatime cli behavior
- use shared path helpers in runtime code (`dependencies`, `index`, `logger`, `state`)
- update docs + tests (including vitest env stubs for clean env isolation)

## quick checks
- `npm run test:run`
- `npm run typecheck`
- `npm run build`

close #40