### PR TITLE
feat: configurable plugin identifier via JSON config

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,30 @@ Inspired by [claude-code-wakatime](https://github.com/wakatime/claude-code-wakat
 - **Rate-limited heartbeats** - 1 per minute per project to avoid API spam
 - **Session lifecycle** - Sends final heartbeat on session idle/end
 - **Batch tool support** - Tracks file operations executed via batch tool
+- **Configurable plugin identifier** - Distinguish OpenCode from forks (e.g. MiMoCode) in the WakaTime dashboard via a config file
+
+## Plugin Configuration
+
+By default, the plugin identifier sent to WakaTime is `opencode-cli/<version>`.
+If you use a fork like [MiMoCode](https://mimo.xiaomi.com), you can distinguish
+it in the WakaTime dashboard by creating a config file at
+`~/.config/opencode/opencode-wakatime.json`:
+
+```json
+{
+  "clientName": "cli",
+  "pluginPrefix": "mimocode-"
+}
+```
+
+With the above, the identifier becomes `mimocode-cli/<version>`.
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `clientName` | env `OPENCODE_CLIENT` or `"cli"` | Overrides the client name portion of the identifier |
+| `pluginPrefix` | `"opencode-"` | Overrides the prefix portion of the identifier |
+
+Both options are optional — omit the file entirely for default `opencode-cli` behavior.
 
 ## Prerequisites
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 import type { Hooks, Plugin } from "@opencode-ai/plugin";
 import { LogLevel, logger } from "./logger.js";
@@ -238,6 +239,7 @@ async function processHeartbeat(
   projectFolder: string,
   opencodeVersion: string,
   opencodeClient: string,
+  pluginPrefix: string,
   force: boolean = false,
 ): Promise<void> {
   if (!shouldSendHeartbeat(force) && !force) {
@@ -266,6 +268,7 @@ async function processHeartbeat(
       isWrite: info.isWrite,
       opencodeVersion,
       opencodeClient,
+      pluginPrefix,
     });
 
     logger.debug(
@@ -327,6 +330,26 @@ export const plugin: Plugin = async (ctx) => {
     // Config file doesn't exist or can't be read, keep default INFO level
   }
 
+  // Read plugin config from ~/.config/opencode/opencode-wakatime.json
+  // Supports: { "clientName": "mimocode", "pluginPrefix": "mimocode-" }
+  // This lets OpenCode and MiMoCode (or other forks) share one plugin build
+  // but distinguish themselves in the WakaTime dashboard.
+  let pluginConfig: { clientName?: string; pluginPrefix?: string } = {};
+  try {
+    const pluginCfgPath = path.join(
+      os.homedir(),
+      ".config",
+      "opencode",
+      "opencode-wakatime.json",
+    );
+    pluginConfig = JSON.parse(fs.readFileSync(pluginCfgPath, "utf-8"));
+    logger.debug(
+      `Loaded plugin config from ${pluginCfgPath}: ${JSON.stringify(pluginConfig)}`,
+    );
+  } catch {
+    // No plugin config file — use defaults
+  }
+
   const { project, worktree, client } = ctx;
 
   // Prefer OpenCode's project paths over the process cwd. GUI/server clients
@@ -336,8 +359,12 @@ export const plugin: Plugin = async (ctx) => {
 
   // Detect opencode client type (cli, desktop, app) from environment
   // Map "app" to "web" for a clearer plugin identifier
-  const rawClient = process.env.OPENCODE_CLIENT || "cli";
+  // pluginConfig.clientName overrides the env-derived client name (e.g. "mimocode")
+  const rawClient =
+    pluginConfig.clientName || process.env.OPENCODE_CLIENT || "cli";
   const opencodeClient = rawClient === "app" ? "web" : rawClient;
+  // pluginPrefix lets the WakaTime dashboard distinguish forks (default "opencode-")
+  const pluginPrefix = pluginConfig.pluginPrefix || "opencode-";
 
   // Fetch opencode version from the server health endpoint
   // Use the SDK client's internal HTTP client which bypasses server auth
@@ -401,7 +428,12 @@ export const plugin: Plugin = async (ctx) => {
 
       // If we have pending file changes, try to send heartbeat
       if (fileChanges.size > 0) {
-        await processHeartbeat(projectFolder, opencodeVersion, opencodeClient);
+        await processHeartbeat(
+          projectFolder,
+          opencodeVersion,
+          opencodeClient,
+          pluginPrefix,
+        );
       }
     },
 
@@ -470,6 +502,7 @@ export const plugin: Plugin = async (ctx) => {
             projectFolder,
             opencodeVersion,
             opencodeClient,
+            pluginPrefix,
           );
         }
       }
@@ -481,6 +514,7 @@ export const plugin: Plugin = async (ctx) => {
           projectFolder,
           opencodeVersion,
           opencodeClient,
+          pluginPrefix,
           true,
         ); // Force send and await
       }

--- a/src/wakatime.ts
+++ b/src/wakatime.ts
@@ -67,6 +67,7 @@ export interface HeartbeatParams {
   isWrite?: boolean;
   opencodeVersion?: string;
   opencodeClient?: string;
+  pluginPrefix?: string;
 }
 
 export function isWindows(): boolean {
@@ -138,6 +139,7 @@ export function sendHeartbeats(
     const [primary, ...extra] = params;
     const client = primary.opencodeClient || "cli";
     const opencodeVersion = primary.opencodeVersion || "unknown";
+    const pluginPrefix = primary.pluginPrefix || "opencode-";
 
     const args: string[] = [
       "--entity",
@@ -147,7 +149,7 @@ export function sendHeartbeats(
       "--category",
       primary.category ?? "ai coding",
       "--plugin",
-      `opencode-${client}/${opencodeVersion} opencode-wakatime/${VERSION}`,
+      `${pluginPrefix}${client}/${opencodeVersion} opencode-wakatime/${VERSION}`,
     ];
 
     if (primary.projectFolder) {


### PR DESCRIPTION
## Summary

Allow forks like [MiMoCode](https://mimo.xiaomi.com) to distinguish themselves in the WakaTime dashboard without forking the plugin source.

## Problem

The `--plugin` identifier sent to wakatime-cli is hardcoded as `opencode-${client}/${version} opencode-wakatime/${version}`. When using MiMoCode (an OpenCode fork), all activity shows up as `opencode-cli` in the WakaTime dashboard — indistinguishable from OpenCode itself.

## Solution

Read an optional JSON config file at `~/.config/opencode/opencode-wakatime.json` with two optional keys:

| Option | Default | Description |
| --- | --- | --- |
| `clientName` | env `OPENCODE_CLIENT` or `"cli"` | Overrides the client name portion |
| `pluginPrefix` | `"opencode-"` | Overrides the prefix portion |

**Example** — for MiMoCode:
```json
{
  "clientName": "cli",
  "pluginPrefix": "mimocode-"
}
```

Resulting identifier: `mimocode-cli/<version> opencode-wakatime/<version>`

## Backward compatibility

Fully backward compatible — no config file means identical default behavior (`opencode-cli`). The `OPENCODE_CLIENT` env var still works as before (config file takes precedence if `clientName` is set).

## Changes

- `src/wakatime.ts`: `HeartbeatParams` gains `pluginPrefix?` field; `--plugin` arg uses `pluginPrefix` instead of hardcoded `opencode-`
- `src/index.ts`: reads optional config file; passes `pluginPrefix` through `processHeartbeat` → heartbeat params
- `README.md`: documents the new config option

## Testing

- `npm run typecheck` ✅
- existing tests pass ✅
- manually verified with MiMoCode: debug log confirms `--plugin "mimocode-cli/0.1.7 opencode-wakatime/1.3.9"`