### PR TITLE
fix: treat root '/' as invalid project folder, fall back to cwd

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -17,6 +17,17 @@ describe("resolveProjectFolder", () => {
   it("falls back to the process cwd when no worktree is available", () => {
     expect(resolveProjectFolder(undefined, undefined, "/cwd")).toBe("/cwd");
   });
+
+  it("treats root '/' as invalid and falls back to cwd", () => {
+    // OpenCode/MiMoCode may pass "/" when no real worktree is active
+    expect(resolveProjectFolder("/", "/", "/cwd")).toBe("/cwd");
+  });
+
+  it("treats root '/' worktree as invalid but uses valid project worktree", () => {
+    expect(resolveProjectFolder("/", "/project-worktree", "/cwd")).toBe(
+      "/project-worktree",
+    );
+  });
 });
 
 describe("extractFileChanges", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -311,7 +311,15 @@ export function resolveProjectFolder(
   projectWorktree: string | undefined,
   cwd: string = process.cwd(),
 ): string {
-  return worktree || projectWorktree || cwd;
+  // Treat "/" as invalid — OpenCode/MiMoCode may pass "/" when no real worktree
+  // is active (e.g. `opencode run` / `mimo run` from CLI), causing the project
+  // name to be empty and show as "unknown" in WakaTime. Fall back to cwd instead.
+  const isValid = (v: string | undefined): v is string => !!v && v !== "/";
+  return isValid(worktree)
+    ? worktree
+    : isValid(projectWorktree)
+      ? projectWorktree
+      : cwd;
 }
 
 export const plugin: Plugin = async (ctx) => {


### PR DESCRIPTION
## Summary

Fix project name showing as "unknown" in WakaTime dashboard when the host passes `"/"` as the worktree.

## Problem

OpenCode and MiMoCode may pass `"/"` as the worktree / project worktree when no real project is active — e.g. when running via `opencode run` / `mimo run` from the CLI. The current logic in `resolveProjectFolder`:

```ts
return worktree || projectWorktree || cwd;
```

treats `"/"` as a valid truthy value, so:
- `projectFolder` becomes `"/"`
- `projectName = path.basename("/")` → `""` (empty string)
- WakaTime shows the project as **"unknown"**

Reproduced with MiMoCode:
```
[DEBUG] ctx.project={"worktree":"/"}, ctx.worktree="/", process.cwd()=/Users/me/code/myproject
[DEBUG] Sending heartbeat: ... --project-folder / ...
```

## Solution

Treat `"/"` as invalid in `resolveProjectFolder`, so it falls back to `process.cwd()`, which holds the correct project directory:

```ts
const isValid = (v) => !!v && v !== "/";
return isValid(worktree) ? worktree
     : isValid(projectWorktree) ? projectWorktree
     : cwd;
```

After fix:
```
[DEBUG] Sending heartbeat: ... --project-folder /Users/me/code/myproject ...
```

## Backward compatibility

No behavior change for valid worktree paths. Only `"/"` (which was never a useful project folder) is now treated as invalid.

## Changes

- `src/index.ts`: `resolveProjectFolder` treats `"/"` as invalid
- `src/__tests__/index.test.ts`: added 2 test cases covering the `"/"` fallback

## Testing

- `npm run typecheck` ✅
- all 26 tests pass (24 existing + 2 new) ✅
- manually verified with MiMoCode: `--project-folder` now shows correct path